### PR TITLE
Added WifiInfo and SupplicantState observation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Contents
 - [Usage](#usage)
   - [Observing WiFi Access Points](#observing-wifi-access-points)
   - [Observing WiFi signal level](#observing-wifi-signal-level)
+  - [Observing WiFi information changes](#observing-wifi-information-changes)
+  - [Observing WPA Supplicant state changes](#observing-wpa-supplicant-state-changes)
 - [Examples](#examples)
 - [Download](#download)
 - [Code style](#code-style)
@@ -31,6 +33,8 @@ Library has the following RxJava Observables available in the public API:
 Observable<List<ScanResult>> observeWifiAccessPoints(final Context context)
 Observable<Integer> observeWifiSignalLevel(final Context context, final int numLevels)
 Observable<WifiSignalLevel> observeWifiSignalLevel(final Context context)
+Observable<SupplicantState> observeSupplicantState(final Context context)
+Observable<WifiInfo> observeWifiAccessPointChanges(final Context context)
 ```
 
 ### Observing WiFi Access Points
@@ -94,6 +98,38 @@ public enum WifiSignalLevel {
   EXCELLENT(4, "excellent");
   ...
 }
+```
+
+### Observing WiFi information changes
+
+We can observe WiFi network information changes with `observeWifiAccessPointChanges(context)` method. Subscriber will be called every time the WiFi network the device is connected to has changed. We can do it in the following way:
+
+```java
+new ReactiveWifi().observeWifiAccessPointChanges(context)
+    .subscribeOn(Schedulers.io())
+    ... // anything else what you can do with RxJava
+    .observeOn(AndroidSchedulers.mainThread())
+    .subscribe(new Action1<WifiInfo>() {
+      @Override public void call(WifiInfo wifiInfo) {
+        // do something with wifiInfo
+      }
+    });
+```
+
+### Observing WPA Supplicant state changes
+
+We can observe changes in the WPA Supplicant state with `observeSupplicantState(context)` method. Subscriber will be called every time the WPA Supplicant will change its state, getting information at a lower level than usually available. We can do it in the following way:
+
+```java
+new ReactiveWifi().observeSupplicantState(context)
+    .subscribeOn(Schedulers.io())
+    ... // anything else what you can do with RxJava
+    .observeOn(AndroidSchedulers.mainThread())
+    .subscribe(new Action1<SupplicantState>() {
+      @Override public void call(SuppicantState state) {
+        // do something with state
+      }
+    });
 ```
 
 Examples

--- a/library/src/main/java/com/github/pwittchen/reactivewifi/ReactiveWifi.java
+++ b/library/src/main/java/com/github/pwittchen/reactivewifi/ReactiveWifi.java
@@ -146,7 +146,7 @@ public class ReactiveWifi {
             SupplicantState supplicantState =
                 intent.getParcelableExtra(WifiManager.EXTRA_NEW_STATE);
 
-            if (SupplicantState.isValidState(supplicantState)) {
+            if ((supplicantState != null) && SupplicantState.isValidState(supplicantState)) {
                subscriber.onNext(supplicantState);
             }
           }

--- a/library/src/main/java/com/github/pwittchen/reactivewifi/ReactiveWifi.java
+++ b/library/src/main/java/com/github/pwittchen/reactivewifi/ReactiveWifi.java
@@ -165,8 +165,7 @@ public class ReactiveWifi {
 
   /**
    * Observes the Wifi network the device is connected to.
-   * Returns the current Wifi network information as a {@link WifiInfo} object, or {@code null}
-   * if Wifi is not enabled.
+   * Returns the current Wifi network information as a {@link WifiInfo} object.
    *
    * @param context Context of the activity or an application
    * @return RxJava Observable with WifiInfo
@@ -196,7 +195,7 @@ public class ReactiveWifi {
           }
         }));
       }
-    }).defaultIfEmpty(null);
+    });
   }
 
   private Subscription unsubscribeInUiThread(final Action0 unsubscribe) {


### PR DESCRIPTION
This PR adds the possibility to track WiFi network changes (changing WiFi networks won't trigger any connectivity changes, for example), and to track the WPA Supplicant state.  Documentation has been updated accordingly, although the sample application only tracks WiFi network changes and WPA Supplicant states via calling `Log.d(...)` instead of adding new UI elements to the activity (sorry for that...)
